### PR TITLE
Rename pigment packageId for custom Nuget build

### DIFF
--- a/src/SingleStoreConnector/SingleStoreConnector.csproj
+++ b/src/SingleStoreConnector/SingleStoreConnector.csproj
@@ -7,7 +7,7 @@
     <Copyright>Copyright 2022-2023 SingleStore Inc.</Copyright>
     <Authors>SingleStore Inc.</Authors>
     <AssemblyName>SingleStoreConnector</AssemblyName>
-    <PackageId>SingleStoreConnector</PackageId>
+    <PackageId>Pigment.SingleStoreConnector</PackageId>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>singlestore;singlestoreconnector;async;ado.net;database;netcore</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
We want to publish a custom build of the S2 client because we want it build with `Release` instead of `Debug`.

This PR renames the packageId to avoid any confusion with the existing Nuget artifacts.